### PR TITLE
add fonts.scale and fonts.dir files for `xset +fp`

### DIFF
--- a/AnonymousPro/fonts.dir
+++ b/AnonymousPro/fonts.dir
@@ -1,0 +1,77 @@
+76
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-adobe-standard
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-ascii-0
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso10646-1
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-1
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-10
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-13
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-15
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-16
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-2
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-3
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-4
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-5
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-9
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-e
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-r
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-ru
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-u
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-uni
+Anonymice powerline bold italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-adobe-standard
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+Anonymice powerline bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-adobe-standard
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-ascii-0
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso10646-1
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-1
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-10
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-13
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-15
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-16
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-2
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-3
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-4
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-5
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-9
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-e
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-r
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-ru
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-u
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-uni
+Anonymice powerline italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-adobe-standard
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Anonymice powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/AnonymousPro/fonts.scale
+++ b/AnonymousPro/fonts.scale
@@ -1,0 +1,77 @@
+76
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-adobe-standard
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-ascii-0
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso10646-1
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-1
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-10
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-13
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-15
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-16
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-2
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-3
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-4
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-5
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-iso8859-9
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-e
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-r
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-ru
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-u
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-koi8-uni
+Anonymice Powerline Bold Italic.ttf -misc-anonymice powerline-bold-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-adobe-standard
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+Anonymice Powerline Bold.ttf -misc-anonymice powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-adobe-standard
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-ascii-0
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso10646-1
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-1
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-10
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-13
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-15
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-16
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-2
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-3
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-4
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-5
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-iso8859-9
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-e
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-r
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-ru
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-u
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-koi8-uni
+Anonymice Powerline Italic.ttf -misc-anonymice powerline-medium-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-adobe-standard
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Anonymice Powerline.ttf -misc-anonymice powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/DejaVuSansMono/fonts.dir
+++ b/DejaVuSansMono/fonts.dir
@@ -1,0 +1,89 @@
+88
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-6.16
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-6.8x
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu sans mono bold for powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-suneu-greek
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-ascii-0
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso10646-1
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-1
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-10
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-13
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-15
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-16
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-2
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-3
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-4
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-5
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-9
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-e
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-r
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-ru
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-u
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-uni
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu sans mono bold oblique for powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-suneu-greek
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp437
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp850
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp866
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-6.16
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-6.8x
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu sans mono for powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-suneu-greek
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ascii-0
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp437
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp850
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp852
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp866
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso10646-1
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-1
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-10
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-13
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-15
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-16
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-2
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-3
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-4
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-5
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-9
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-e
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-r
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-ru
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-u
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-uni
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu sans mono oblique for powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-suneu-greek

--- a/DejaVuSansMono/fonts.scale
+++ b/DejaVuSansMono/fonts.scale
@@ -1,0 +1,89 @@
+88
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-ascii-0
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso10646-1
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-1
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-10
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-13
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-15
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-16
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-2
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-3
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-4
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-5
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-iso8859-9
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-e
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-r
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-ru
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-u
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-koi8-uni
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu Sans Mono Bold Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-bold-o-normal--0-0-0-0-m-0-suneu-greek
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-6.16
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-6.8x
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu Sans Mono Bold for Powerline.ttf -misc-dejavu sans mono for powerline-bold-r-normal--0-0-0-0-m-0-suneu-greek
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ascii-0
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp437
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp850
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp852
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-ibm-cp866
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso10646-1
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-1
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-10
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-13
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-15
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-16
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-2
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-3
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-4
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-5
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-iso8859-9
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-e
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-r
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-ru
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-u
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-koi8-uni
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu Sans Mono Oblique for Powerline.ttf -misc-dejavu sans mono for powerline-medium-o-normal--0-0-0-0-m-0-suneu-greek
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp437
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp850
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp866
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-6.16
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-6.8x
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+DejaVu Sans Mono for Powerline.ttf -misc-dejavu sans mono for powerline-medium-r-normal--0-0-0-0-m-0-suneu-greek

--- a/DroidSansMono/fonts.dir
+++ b/DroidSansMono/fonts.dir
@@ -1,0 +1,19 @@
+18
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Droid sans mono for powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/DroidSansMono/fonts.scale
+++ b/DroidSansMono/fonts.scale
@@ -1,0 +1,19 @@
+18
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Droid Sans Mono for Powerline.otf -misc-droid sans mono for powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/Inconsolata/fonts.dir
+++ b/Inconsolata/fonts.dir
@@ -1,0 +1,7 @@
+6
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Inconsolata for powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9

--- a/Inconsolata/fonts.scale
+++ b/Inconsolata/fonts.scale
@@ -1,0 +1,7 @@
+6
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Inconsolata for Powerline.otf -misc-inconsolata for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9

--- a/InconsolataDz/fonts.dir
+++ b/InconsolataDz/fonts.dir
@@ -1,0 +1,7 @@
+6
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Inconsolata-dz for powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9

--- a/InconsolataDz/fonts.scale
+++ b/InconsolataDz/fonts.scale
@@ -1,0 +1,7 @@
+6
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Inconsolata-dz for Powerline.otf -misc-inconsolata dz for powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9

--- a/LiberationMono/fonts.dir
+++ b/LiberationMono/fonts.dir
@@ -1,0 +1,101 @@
+100
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-adobe-standard
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ascii-0
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp437
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp850
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp852
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp866
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso10646-1
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-1
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-10
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-13
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-15
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-16
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-2
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-3
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-4
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-5
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-8
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-9
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-e
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-r
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-ru
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-u
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-uni
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation mono powerline bold italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-suneu-greek
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-adobe-standard
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ascii-0
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp437
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp850
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp852
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp866
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso10646-1
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-1
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-10
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-13
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-15
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-16
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-2
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-3
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-4
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-5
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-8
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-9
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-e
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-r
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-ru
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-u
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-uni
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation mono powerline bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-suneu-greek
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-adobe-standard
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ascii-0
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp437
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp850
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp852
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp866
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso10646-1
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-1
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-10
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-13
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-15
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-16
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-2
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-3
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-4
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-5
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-8
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-9
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-e
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-r
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-ru
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-u
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-uni
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation mono powerline italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-suneu-greek
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-adobe-standard
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-8
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation mono powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek

--- a/LiberationMono/fonts.scale
+++ b/LiberationMono/fonts.scale
@@ -1,0 +1,101 @@
+100
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-adobe-standard
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ascii-0
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp437
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp850
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp852
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-ibm-cp866
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso10646-1
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-1
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-10
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-13
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-15
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-16
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-2
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-3
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-4
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-5
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-8
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-iso8859-9
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-e
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-r
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-ru
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-u
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-koi8-uni
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation Mono Powerline Bold Italic.ttf -misc-literation mono powerline-bold-i-normal--0-0-0-0-p-0-suneu-greek
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-adobe-standard
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ascii-0
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp437
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp850
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp852
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-ibm-cp866
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso10646-1
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-1
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-10
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-13
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-15
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-16
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-2
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-3
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-4
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-5
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-8
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-iso8859-9
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-e
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-r
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-ru
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-u
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-koi8-uni
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation Mono Powerline Bold.ttf -misc-literation mono powerline-bold-r-normal--0-0-0-0-p-0-suneu-greek
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-adobe-standard
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ascii-0
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp437
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp850
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp852
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-ibm-cp866
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso10646-1
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-1
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-10
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-13
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-15
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-16
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-2
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-3
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-4
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-5
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-8
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-iso8859-9
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-e
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-r
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-ru
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-u
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-koi8-uni
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation Mono Powerline Italic.ttf -misc-literation mono powerline-medium-i-normal--0-0-0-0-p-0-suneu-greek
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-adobe-standard
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-8
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Literation Mono Powerline.ttf -misc-literation mono powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek

--- a/Meslo/fonts.dir
+++ b/Meslo/fonts.dir
@@ -1,0 +1,139 @@
+138
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg l dz regular for powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg l regular for powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg m dz regular for powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg m regular for powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg s dz regular for powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo lg s regular for powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek

--- a/Meslo/fonts.scale
+++ b/Meslo/fonts.scale
@@ -1,0 +1,139 @@
+138
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG L DZ Regular for Powerline.otf -bitstream-meslo lg l dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG L Regular for Powerline.otf -bitstream-meslo lg l for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG M DZ Regular for Powerline.otf -bitstream-meslo lg m dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG M Regular for Powerline.otf -bitstream-meslo lg m for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG S DZ Regular for Powerline.otf -bitstream-meslo lg s dz for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ascii-0
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp437
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp850
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp852
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-ibm-cp866
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso10646-1
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-1
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-10
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-13
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-15
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-16
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-2
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-3
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-4
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-5
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-iso8859-9
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-e
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-r
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-ru
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-u
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-koi8-uni
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-microsoft-cp1252
+Meslo LG S Regular for Powerline.otf -bitstream-meslo lg s for powerline-medium-r-normal--0-0-0-0-p-0-suneu-greek

--- a/SourceCodePro/fonts.dir
+++ b/SourceCodePro/fonts.dir
@@ -1,0 +1,78 @@
+77
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline extralight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-ascii-0
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce code powerline semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/SourceCodePro/fonts.scale
+++ b/SourceCodePro/fonts.scale
@@ -1,0 +1,78 @@
+77
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Black.otf -adobe-source code pro black-black-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Bold.otf -adobe-sauce code powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline ExtraLight.otf -adobe-source code pro extralight-extralight-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Light.otf -adobe-source code pro light-light-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Medium.otf -adobe-source code pro medium-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Regular.otf -adobe-sauce code powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-ascii-0
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-ibm-cp852
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso10646-1
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-1
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-13
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-15
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-16
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-2
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-3
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-iso8859-9
+Sauce Code Powerline Semibold.otf -adobe-source code pro semibold-semibold-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/Terminus/BDF/fonts.dir
+++ b/Terminus/BDF/fonts.dir
@@ -1,0 +1,19 @@
+18
+ter-x12b.bdf -xos4-terminesspowerline-bold-r-normal--12-120-72-72-c-60-iso10646-1
+ter-x12n.bdf -xos4-terminesspowerline-medium-r-normal--12-120-72-72-c-60-iso10646-1
+ter-x14b.bdf -xos4-terminesspowerline-bold-r-normal--14-140-72-72-c-80-iso10646-1
+ter-x14n.bdf -xos4-terminesspowerline-medium-r-normal--14-140-72-72-c-80-iso10646-1
+ter-x16b.bdf -xos4-terminesspowerline-bold-r-normal--16-160-72-72-c-80-iso10646-1
+ter-x16n.bdf -xos4-terminesspowerline-medium-r-normal--16-160-72-72-c-80-iso10646-1
+ter-x18b.bdf -xos4-terminesspowerline-bold-r-normal--18-180-72-72-c-100-iso10646-1
+ter-x18n.bdf -xos4-terminesspowerline-medium-r-normal--18-180-72-72-c-100-iso10646-1
+ter-x20b.bdf -xos4-terminesspowerline-bold-r-normal--20-200-72-72-c-100-iso10646-1
+ter-x20n.bdf -xos4-terminesspowerline-medium-r-normal--20-200-72-72-c-100-iso10646-1
+ter-x22b.bdf -xos4-terminesspowerline-bold-r-normal--22-220-72-72-c-110-iso10646-1
+ter-x22n.bdf -xos4-terminesspowerline-medium-r-normal--22-220-72-72-c-110-iso10646-1
+ter-x24b.bdf -xos4-terminesspowerline-bold-r-normal--24-240-72-72-c-120-iso10646-1
+ter-x24n.bdf -xos4-terminesspowerline-medium-r-normal--24-240-72-72-c-120-iso10646-1
+ter-x28b.bdf -xos4-terminesspowerline-bold-r-normal--28-280-72-72-c-140-iso10646-1
+ter-x28n.bdf -xos4-terminesspowerline-medium-r-normal--28-280-72-72-c-140-iso10646-1
+ter-x32b.bdf -xos4-terminesspowerline-bold-r-normal--32-320-72-72-c-160-iso10646-1
+ter-x32n.bdf -xos4-terminesspowerline-medium-r-normal--32-320-72-72-c-160-iso10646-1

--- a/Terminus/PCF/fonts.dir
+++ b/Terminus/PCF/fonts.dir
@@ -1,0 +1,19 @@
+18
+ter-x12b.pcf.gz -xos4-terminesspowerline-bold-r-normal--12-120-72-72-c-60-iso10646-1
+ter-x12n.pcf.gz -xos4-terminesspowerline-medium-r-normal--12-120-72-72-c-60-iso10646-1
+ter-x14b.pcf.gz -xos4-terminesspowerline-bold-r-normal--14-140-72-72-c-80-iso10646-1
+ter-x14n.pcf.gz -xos4-terminesspowerline-medium-r-normal--14-140-72-72-c-80-iso10646-1
+ter-x16b.pcf.gz -xos4-terminesspowerline-bold-r-normal--16-160-72-72-c-80-iso10646-1
+ter-x16n.pcf.gz -xos4-terminesspowerline-medium-r-normal--16-160-72-72-c-80-iso10646-1
+ter-x18b.pcf.gz -xos4-terminesspowerline-bold-r-normal--18-180-72-72-c-100-iso10646-1
+ter-x18n.pcf.gz -xos4-terminesspowerline-medium-r-normal--18-180-72-72-c-100-iso10646-1
+ter-x20b.pcf.gz -xos4-terminesspowerline-bold-r-normal--20-200-72-72-c-100-iso10646-1
+ter-x20n.pcf.gz -xos4-terminesspowerline-medium-r-normal--20-200-72-72-c-100-iso10646-1
+ter-x22b.pcf.gz -xos4-terminesspowerline-bold-r-normal--22-220-72-72-c-110-iso10646-1
+ter-x22n.pcf.gz -xos4-terminesspowerline-medium-r-normal--22-220-72-72-c-110-iso10646-1
+ter-x24b.pcf.gz -xos4-terminesspowerline-bold-r-normal--24-240-72-72-c-120-iso10646-1
+ter-x24n.pcf.gz -xos4-terminesspowerline-medium-r-normal--24-240-72-72-c-120-iso10646-1
+ter-x28b.pcf.gz -xos4-terminesspowerline-bold-r-normal--28-280-72-72-c-140-iso10646-1
+ter-x28n.pcf.gz -xos4-terminesspowerline-medium-r-normal--28-280-72-72-c-140-iso10646-1
+ter-x32b.pcf.gz -xos4-terminesspowerline-bold-r-normal--32-320-72-72-c-160-iso10646-1
+ter-x32n.pcf.gz -xos4-terminesspowerline-medium-r-normal--32-320-72-72-c-160-iso10646-1

--- a/UbuntuMono/fonts.dir
+++ b/UbuntuMono/fonts.dir
@@ -1,0 +1,77 @@
+76
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-ascii-0
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-e
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-r
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-u
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu mono derivative powerline bold italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu mono derivative powerline bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-ascii-0
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-e
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-r
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-u
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu mono derivative powerline italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu mono derivative powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252

--- a/UbuntuMono/fonts.scale
+++ b/UbuntuMono/fonts.scale
@@ -1,0 +1,77 @@
+76
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-ascii-0
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-e
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-r
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-u
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu Mono derivative Powerline Bold Italic.ttf -misc-ubuntu mono derivative powerline-bold-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-ascii-0
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-e
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-r
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-u
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu Mono derivative Powerline Bold.ttf -misc-ubuntu mono derivative powerline-bold-r-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-ascii-0
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-e
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-r
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-u
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu Mono derivative Powerline Italic.ttf -misc-ubuntu mono derivative powerline-medium-i-normal--0-0-0-0-m-0-microsoft-cp1252
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-adobe-standard
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-ascii-0
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso10646-1
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-1
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-10
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-13
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-15
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-16
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-2
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-3
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-4
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-5
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-iso8859-9
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-e
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-r
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-ru
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-u
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-koi8-uni
+Ubuntu Mono derivative Powerline.ttf -misc-ubuntu mono derivative powerline-medium-r-normal--0-0-0-0-m-0-microsoft-cp1252


### PR DESCRIPTION
The fonts.scale files were generated by running `mkfontscale ./**/` and
the fonts.dir files were generated by running `mkfontdir ./**/` in this
Git repository's working tree.  Run those commands again to regenerate.

These generated files let you register their corresponding True Type
fonts with the `xset +fp` command, which "installs" them under Linux.
For example, you would do this by running the following commands if you
cloned this Git repository to your ~/.fonts/powerline-fonts/ directory:

``` sh
xset +fp ~/.fonts/powerline-fonts/AnonymousPro
xset +fp ~/.fonts/powerline-fonts/DejaVuSansMono
xset +fp ~/.fonts/powerline-fonts/DroidSansMono
xset +fp ~/.fonts/powerline-fonts/InconsolataDz
xset +fp ~/.fonts/powerline-fonts/Inconsolata
xset +fp ~/.fonts/powerline-fonts/LiberationMono
xset +fp ~/.fonts/powerline-fonts/Meslo
xset +fp ~/.fonts/powerline-fonts/SourceCodePro
xset +fp ~/.fonts/powerline-fonts/Terminus/BDF
xset +fp ~/.fonts/powerline-fonts/Terminus/PCF
xset +fp ~/.fonts/powerline-fonts/UbuntuMono
xset fp rehash
```
