### PR TITLE
Adds a fontconfig file which should resolve issues with using Terminess ...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,8 @@ patched font! See the `Powerline font installation instructions`__ for
 details.
 
 __ https://powerline.readthedocs.org/en/latest/installation/linux.html#font-installation
+
+Fontconfig
+----------
+
+In some distributions, Terminess Powerline is ignored by default and must be explicitly allowed. A fontconfig file is provided which enables it. Copy this file from the fontconfig directory to your home folder under `~/.config/fontconfig/conf.d` (create it if it doesn't exist) and re-run `fc-cache -vf`.

--- a/fontconfig/50-enable-terminess-powerline.conf
+++ b/fontconfig/50-enable-terminess-powerline.conf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+  <selectfont>
+    <acceptfont>
+      <pattern>
+        <patelt name="family"><string>terminess powerline</string></patelt>
+      </pattern>
+    </acceptfont>
+  </selectfont>
+</fontconfig>


### PR DESCRIPTION
In order to use Terminess Powerline, I had to write a fontconfig file to enable it before it would be recognised by `fc-cache`. This commit adds it to the repository as well as a short message to the readme on how to use it.
