### PR TITLE
install.sh should also install Terminus font extension (pcf.gz) 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ else
 fi
 
 # Copy all fonts to user fonts directory
-find_command="find $powerline_fonts_dir -name '*.[o,t]tf' -type f -print0"
+find_command="find $powerline_fonts_dir -name '*.[o,t]tf' -o -name '*.pcf.gz' -type f -print0"
 eval $find_command | xargs -0 -I % cp % $font_dir/
 
 # Reset font cache on Linux


### PR DESCRIPTION
The current script to install the fonts skips Terminus patched font extension, this pr fixes that.
