### PR TITLE
*.otf & *.ttf files were not being copied due to recent changes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,8 @@ else
 fi
 
 # Copy all fonts to user fonts directory
-find_command="find $powerline_fonts_dir -name '*.[o,t]tf' -o -name '*.pcf.gz' -type f -print0"
-eval $find_command | xargs -0 -I % cp % $font_dir/
+find_command="find $powerline_fonts_dir -name '*.[o,t]tf' -o -name '*.pcf.gz' -type f"
+eval $find_command | xargs -I % cp '%' $font_dir/
 
 # Reset font cache on Linux
 if [[ -n `which fc-cache` ]]; then


### PR DESCRIPTION
On OSX, `*.otf` or `*.ttf` files were not being copied after running `install.sh`. I had to use the following patch to install the fonts aptly.
