### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,14 +3,14 @@
 # Set source and target directories
 powerline_fonts_dir=$( cd "$( dirname "$0" )" && pwd )
 
+find_command="find $powerline_fonts_dir \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
+
 if [[ `uname` == 'Darwin' ]]; then
   # MacOS
   font_dir="$HOME/Library/Fonts"
-  find_command="find $powerline_fonts_dir \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
 else
   # Linux
   font_dir="$HOME/.fonts"
-  find_command="find $powerline_fonts_dir -name '*.[o,t]tf' -o -name '*.pcf.gz' -type f -print0"
   mkdir -p $font_dir
 fi
 


### PR DESCRIPTION
This script was only copying over the pcf.gz files on OSX 10.9 and 10.10 since the find command is a little different.
