### PR TITLE
Allow spaces in powerline fonts source dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Set source and target directories
 powerline_fonts_dir=$( cd "$( dirname "$0" )" && pwd )
 
-find_command="find $powerline_fonts_dir \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
+find_command="find \"$powerline_fonts_dir\" \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
 
 if [[ `uname` == 'Darwin' ]]; then
   # MacOS
@@ -15,7 +15,7 @@ else
 fi
 
 # Copy all fonts to user fonts directory
-eval $find_command | xargs -0 -I % cp % $font_dir/
+eval $find_command | xargs -0 -I % cp "%" "$font_dir/"
 
 # Reset font cache on Linux
 if [[ -n `which fc-cache` ]]; then


### PR DESCRIPTION
Fixes an error when running `install.sh` within a path containing spaces (and eventually other special characters), in my case `/Volumes/Big HD/Users/sebu/SCM/3rd-party/powerline-fonts--git`

I got the following error, which I fixed by this PR:

> find: /Volumes/Big: No such file or directory
> find: HD/Users/sebu/SCM/3rd-party/powerline-fonts--git: No such file or directory
