### PR TITLE
Fixed typo in the heading for `Fira Powerline`

### DIFF
--- a/FiraMono/README.rst
+++ b/FiraMono/README.rst
@@ -1,4 +1,4 @@
-Fura Powerline
+Fira Powerline
 ==============
 
 :Font creator: Erik Spiekermann, Ralph du Carrois (Carrois Type Design, Mozilla Foundation)


### PR DESCRIPTION
`Fira` was misspelled as `Fura`