### PR TITLE
Fixed wrong fonts directory in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ if [[ `uname` == 'Darwin' ]]; then
   font_dir="$HOME/Library/Fonts"
 else
   # Linux
-  font_dir="$HOME/.fonts"
+  font_dir="$HOME/.local/share/fonts"
   mkdir -p $font_dir
 fi
 


### PR DESCRIPTION
~/.fonts as normal user font config directory is deprecated since fonconfig 2.10.1, see above:
http://cgit.freedesktop.org/fontconfig/commit/?id=8c255fb185d5651b57380b0a9443001e8051b29d