### PR TITLE
Link to Powerline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Powerline fonts
 ===============
 
 This repository contains pre-patched and adjusted fonts for usage with
-the new Powerline plugin.
+the `Powerline <https://github.com/powerline/powerline>`_ statusline plugin.
 
 Installation
 ------------


### PR DESCRIPTION
Users who land here because [the README of a zsh theme](https://github.com/wesbos/Cobalt2-iterm) told them they need to patch the Powerline font for Zsh, have no idea what Powerline is.