### PR TITLE
Addded a font selection option to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,13 @@
 # Set source and target directories
 powerline_fonts_dir=$( cd "$( dirname "$0" )" && pwd )
 
-find_command="find \"$powerline_fonts_dir\" \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
+# if an argument is given it is used to select wich fonts to install
+prefix=''
+if [ $# = 1 ]; then
+	prefix=$1
+fi
+
+find_command="find \"$powerline_fonts_dir\" \( -name '$prefix*.[o,t]tf' -or -name '$prefix*.pcf.gz' \) -type f -print0"
 
 if [[ `uname` == 'Darwin' ]]; then
   # MacOS
@@ -22,4 +28,4 @@ if [[ -n `which fc-cache` ]]; then
   fc-cache -f $font_dir
 fi
 
-echo "All Powerline fonts installed to $font_dir"
+echo "Powerline fonts installed to $font_dir"


### PR DESCRIPTION
Needed to install just some of the fonts. this version uses the first argument, if it is given, as a fileglob prefix.

   ./install.sh Inconsolata 

Installs all the Inconsolata\* fonts
