### PR TITLE
Avoid hard-coded bash path in sha-bang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set source and target directories
 powerline_fonts_dir=$( cd "$( dirname "$0" )" && pwd )


### PR DESCRIPTION
Make it work on other unix (e.g. bsd family). :smile: 
