### PR TITLE
Update install.sh to help OpenBSD users

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ fi
 
 # Copy all fonts to user fonts directory
 echo "Copying fonts..."
-eval $find_command | xargs -0 -I % cp "%" "$font_dir/"
+eval $find_command | xargs -0 -n1 -I % cp "%" "$font_dir/"
 
 # Reset font cache on Linux
 if command -v fc-cache @>/dev/null ; then


### PR DESCRIPTION
This fixes the following error received on OpenBSD when running `install.sh`.

```
$ sh install.sh
Copying fonts...
cp: cannot stat '%': No such file or directory
All Powerline fonts installed to /home/foo/.local/share/fonts
```

What's happening is that OpenBSD's `xargs` fails without the `-n1` option (i.e. copy the files one-at-a-time).

Adding the `-n1` seems to be compatible with Linux (I tried it on a CentOS system); probably holds for Mac OS X too (but I don't have one to test on).