### PR TITLE
Updates README.rst with link to Input's license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Font Families
  Inconsolata for Powerline               Inconsolata               SIL Open Font License, Version 1.0
  Inconsolata-dz for Powerline            Inconsolata-dz            SIL Open Font License, Version 1.0
  Inconsolata-g for Powerline             Inconsolata-g             SIL Open Font License, Version 1.0
- Input Mono                              Input Mono                Input’s license
+ Input Mono                              Input Mono                `Input’s license <http://input.fontbureau.com/license/>`_
  Literation Mono Powerline               Liberation Mono           SIL Open Font License, Version 1.1
  ProFontWindows                          ProFont for Powerline     MIT License
  Meslo for Powerline                     Meslo                     Apache License, Version 2.0


### PR DESCRIPTION
Makes usage terms a bit more accessible, since Input has its own custom license agreement with different term for private and public usage.