### PR TITLE
Update Quick Installation script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Quick installation
 You can copy and paste the commands to your terminal. Comments are fine too.
 ::
     # clone
-    git clone https://github.com/powerline/fonts.git
+    git clone https://github.com/powerline/fonts.git --depth=1
     # install
     cd fonts
     ./install.sh


### PR DESCRIPTION
Quick Installation does not need cloning the whole history of the repo, especially if they're going to delete the whole folder immediately.
So added ``--depth=1`` option to ``git clone``