### PR TITLE
README.rst: Add link to config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Fontconfig
 ----------
 
 In some distributions, Terminess Powerline is ignored by default and must be 
-explicitly allowed. A fontconfig file is provided which enables it. Copy this 
-file from the fontconfig directory to your home folder under 
-``~/.config/fontconfig/conf.d`` (create it if it doesn't exist) and re-run 
-``fc-cache -vf``.
+explicitly allowed. A fontconfig file is provided which enables it. Copy `this
+file <https://github.com/powerline/fonts/blob/master/fontconfig/50-enable-terminess-powerline.conf>`_
+from the fontconfig directory to your home folder under ``~/.config/fontconfig/conf.d`` 
+(create it if it doesn't exist) and re-run ``fc-cache -vf``.


### PR DESCRIPTION
Makes Font config section more simple and 
comprehensible as it is unintelligible to tell
while file, the reference 'this file' refers to.