### PR TITLE
Use /bin/sh as the interpreter for installation script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Set source and target directories
 powerline_fonts_dir="$( cd "$( dirname "$0" )" && pwd )"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Set source and target directories
 powerline_fonts_dir="$( cd "$( dirname "$0" )" && pwd )"


### PR DESCRIPTION
Users of *BSD systems will usually have bash installed under /usr/local or something of the sort.

There were two viable options here, the other is to use the `env` tool to determine the location of bash.

 However, after linting this file with the `sh` installed on my system,
I decided that this will do.