### PR TITLE
Faster install with powershell

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -32,9 +32,7 @@ foreach ($aFontName in $FontName) {
 $installDir = "./installPlease"
 $installDirItem = New-Item $installDir -ItemType Directory -Force
 
-foreach ($fontFile in $fontFiles) {
-    Copy-Item -Force -Path $fontFile.FullName -Destination $installDir -Container
-}
+$fontFiles | Copy-Item -Force -Destination $installDirItem
 
 if ($PSCmdlet.ShouldProcess($fontFiles, "Install fonts")) {
   $shellApp = New-Object -ComObject shell.application


### PR DESCRIPTION
Installing a font at a time took forever, especially when overwriting... So I made a folder and copied all the fonts at once. Allows to overwrite all at once.

This is hundred times faster.