### PR TITLE
Ignore fontconfig .uuid generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore fontconfig .uuid files
+.uuid


### PR DESCRIPTION
If using powerline/fonts via a git submodule, certain linux systems may
generate .uuid files. This prevents accidentally committing these
artifacts in case a user doesn't have it in ~.gitignore_global.

See also:
- https://forum.antergos.com/topic/9573/uuid-files-being-created-fonts
- https://www.freedesktop.org/software/fontconfig/fontconfig-devel/fcdircachecreateuuid.html