### PR TITLE
Update Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ iTerm2 users need to set both the Regular font and the Non-ASCII Font in
 
 __ https://github.com/Lokaltog/powerline-fonts/issues/44
 
-or enable `Powerline glyphs` )per (per `this issue`__).
+or enable `Powerline glyphs` (per `this issue`__).
 
 __ https://github.com/agnoster/agnoster-zsh-theme/issues/163#issuecomment-1026651162
 

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,10 @@ iTerm2 users need to set both the Regular font and the Non-ASCII Font in
 
 __ https://github.com/Lokaltog/powerline-fonts/issues/44
 
+or enable `Powerline glyphs` )per (per `this issue`__).
+
+__ https://github.com/agnoster/agnoster-zsh-theme/issues/163#issuecomment-1026651162
+
 Fontconfig
 ----------
 


### PR DESCRIPTION
Iterm2 users can get the rendering work properly even by enabling Powerline Glyphs option. This is now updated in ReadMe.