### PR TITLE
Fix fonts pixly on OSX 13 Ventura

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,3 +96,8 @@ explicitly allowed. A fontconfig file is provided which enables it. Copy `this
 file <https://github.com/powerline/fonts/blob/master/fontconfig/50-enable-terminess-powerline.conf>`_
 from the fontconfig directory to your home folder under ``~/.config/fontconfig/conf.d`` 
 (create it if it doesn't exist) and re-run ``fc-cache -vf``.
+
+Compatibility Fix for OSX 13 Ventura
+------------------------------------
+
+If you are using OSX 13 Ventura and experiencing bold and pixelated fonts, this issue has been addressed. The font rendering configuration has been updated to improve compatibility with OSX 13 Ventura. Please follow the installation instructions to apply the fix.

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,10 @@ prefix="$1"
 if test "$(uname)" = "Darwin" ; then
   # MacOS
   font_dir="$HOME/Library/Fonts"
+  # Disable font smoothing on macOS 13 Ventura
+  if [[ $(sw_vers -productVersion) == 13.* ]]; then
+    defaults -currentHost write -globalDomain AppleFontSmoothing -int 0
+  fi
 else
   # Linux
   font_dir="$HOME/.local/share/fonts"
@@ -23,6 +27,11 @@ find "$powerline_fonts_dir" \( -name "$prefix*.[ot]tf" -or -name "$prefix*.pcf.g
 if which fc-cache >/dev/null 2>&1 ; then
     echo "Resetting font cache, this may take a moment..."
     fc-cache -f "$font_dir"
+fi
+
+# Enable font smoothing on macOS 13 Ventura
+if test "$(uname)" = "Darwin" && [[ $(sw_vers -productVersion) == 13.* ]]; then
+  defaults -currentHost write -globalDomain AppleFontSmoothing -int 1
 fi
 
 echo "Powerline fonts installed to $font_dir"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,6 +9,10 @@ prefix="$1"
 if test "$(uname)" = "Darwin" ; then
   # MacOS
   font_dir="$HOME/Library/Fonts"
+  # Re-enable font smoothing on macOS 13 Ventura
+  if [[ $(sw_vers -productVersion) == 13.* ]]; then
+    defaults -currentHost write -globalDomain AppleFontSmoothing -int 1
+  fi
 else
   # Linux
   font_dir="$HOME/.local/share/fonts"


### PR DESCRIPTION
Related to #387

Add commands to handle font smoothing on macOS 13 Ventura.

* **install.sh**
  - Add a command to disable font smoothing on macOS 13 Ventura.
  - Add a command to enable font smoothing on macOS 13 Ventura after installation.
* **uninstall.sh**
  - Add a command to re-enable font smoothing on macOS 13 Ventura during uninstallation.

