### PR TITLE
Fix icons not showing on WSL Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,20 @@ On other environments, you can copy and paste these commands to your terminal. C
     cd ..
     rm -rf fonts
 
+Installing and Configuring Fonts on WSL Ubuntu
+----------------------------------------------
+
+If you are using WSL Ubuntu and experiencing issues with icons not showing correctly, follow these steps to install and configure fonts:
+
+1. Install the necessary packages:
+::
+    sudo apt-get update
+    sudo apt-get install fonts-powerline
+
+2. Configure the font settings in your terminal emulator (e.g., Windows Terminal, Hyper, etc.) to use a Powerline font.
+
+3. If the issue persists, try using the DejaVu or Sarasa Term SC fonts, as they have been reported to work correctly on WSL Ubuntu.
+
 Uninstall
 ---------
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,12 @@ prefix="$1"
 if test "$(uname)" = "Darwin" ; then
   # MacOS
   font_dir="$HOME/Library/Fonts"
+elif grep -qEi "(Microsoft|WSL)" /proc/version &> /dev/null ; then
+  # WSL Ubuntu
+  font_dir="$HOME/.local/share/fonts"
+  mkdir -p $font_dir
+  sudo apt-get update
+  sudo apt-get install -y fonts-powerline
 else
   # Linux
   font_dir="$HOME/.local/share/fonts"

--- a/samples/DejaVuSansMono.md
+++ b/samples/DejaVuSansMono.md
@@ -1,2 +1,13 @@
 #DejaVuSansMono
 ![](https://cloud.githubusercontent.com/assets/8317250/7021756/221ca1b0-dd60-11e4-8e03-a3d0cd9595e3.png)
+
+Note: If you are using WSL Ubuntu and experiencing issues with icons not showing correctly, follow these steps to install and configure fonts:
+
+1. Install the necessary packages:
+::
+    sudo apt-get update
+    sudo apt-get install fonts-powerline
+
+2. Configure the font settings in your terminal emulator (e.g., Windows Terminal, Hyper, etc.) to use a Powerline font.
+
+3. If the issue persists, try using the DejaVu or Sarasa Term SC fonts, as they have been reported to work correctly on WSL Ubuntu.


### PR DESCRIPTION
Related to #345

Add instructions for installing and configuring fonts on WSL Ubuntu.

* **README.rst**
  - Add a section for installing and configuring fonts on WSL Ubuntu.
  - Provide steps to install necessary packages and configure font settings.
  - Mention DejaVu and Sarasa Term SC fonts as potential solutions.

* **samples/DejaVuSansMono.md**
  - Add a note about the issue with icons on WSL Ubuntu.
  - Provide steps to install necessary packages and configure font settings.
  - Mention DejaVu and Sarasa Term SC fonts as potential solutions.

* **install.sh**
  - Add support for WSL Ubuntu.
  - Install fonts-powerline package on WSL Ubuntu.
  - Set font directory to `$HOME/.local/share/fonts` for WSL Ubuntu.

